### PR TITLE
cosmetic tweak

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,6 +1,7 @@
 ﻿$packageName = 'obs-mp'
 $installerType = 'EXE'
 $url = 'https://github.com/jp9000/obs-studio/releases/download/0.13.2/OBS-Studio-0.13.2-Installer.exe'
+$url64 = $url
 $silentArgs = '/S'
 $validExitCodes = @(0)
-Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" -validExitCodes $validExitCodes
+Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" "$url64" -validExitCodes $validExitCodes


### PR DESCRIPTION
Give chocolatey a $url64, so the install will say "installing obs-mp 64bit" on x64 machines.
